### PR TITLE
Reflect `hawebapp` -> `ha-webapp` rename in meta and uptest setup script

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,10 +1,10 @@
 apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Configuration
 metadata:
-  name: platform-ref-azure-hawebapp
+  name: platform-ref-azure-ha-webapp
   annotations:
     meta.crossplane.io/maintainer: Upbound <support@upbound.io>
-    meta.crossplane.io/source: github.com/upbound/platform-ref-azure-hawebapp
+    meta.crossplane.io/source: github.com/upbound/platform-ref-azure-ha-webapp
     meta.crossplane.io/license: Apache-2.0
     meta.crossplane.io/description: |
       This reference platform Configuration for Azure highly available multi-region web app
@@ -14,7 +14,7 @@ metadata:
       following well-architected best practices, inspired by https://azure.github.io/AppService/2022/12/02/multi-region-web-app.html
 
       To learn more checkout the [GitHub
-      repo](https://github.com/upbound/platform-ref-azure-hawebapp/) that you can copy and
+      repo](https://github.com/upbound/platform-ref-azure-ha-webapp/) that you can copy and
       customize to meet the exact needs of your organization!
 spec:
   crossplane:

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -3,8 +3,8 @@ set -aeuo pipefail
 
 echo "Running setup.sh"
 echo "Waiting until configuration package is healthy/installed..."
-${KUBECTL} wait configuration.pkg platform-ref-azure-hawebapp --for=condition=Healthy --timeout 5m
-${KUBECTL} wait configuration.pkg platform-ref-azure-hawebapp --for=condition=Installed --timeout 5m
+${KUBECTL} wait configuration.pkg platform-ref-azure-ha-webapp --for=condition=Healthy --timeout 5m
+${KUBECTL} wait configuration.pkg platform-ref-azure-ha-webapp --for=condition=Installed --timeout 5m
 
 echo "Creating cloud credential secret..."
 ${KUBECTL} -n upbound-system create secret generic azure-creds --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" \


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Reflect `hawebapp` -> `ha-webapp` rename in meta and uptest setup script

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

will execute uptest below
